### PR TITLE
Add spreadsheet-to-format.json sync automation with WIF auth.

### DIFF
--- a/.github/SHEET_SYNC_SETUP.md
+++ b/.github/SHEET_SYNC_SETUP.md
@@ -1,0 +1,179 @@
+# Sheet sync setup
+
+`format.json` can be regenerated from the Firmware Signal Spreadsheet via a GitHub Action or a local dry-run. This document covers one-time setup and local testing.
+
+Parsed tabs: `PDC_SC2`, `Steering Wheel`, `MPPT`, `Powertrain`, `MCC`, `Software`, `Race Strategy`. Tabs with `SC1` in the name, plus `Title Page` and `Better Template`, are skipped. All `Battery;BMS` and `pack_power` entries are preserved from the committed `format.json`.
+
+## Trigger the workflow
+
+In the repo: **Actions → Sync format.json from spreadsheet → Run workflow**.
+
+- Leave **dry_run** unchecked to sync and open a pull request.
+- Check **dry_run** to parse the sheet and upload a report artifact without opening a PR.
+
+## Required GitHub secrets
+
+| Secret | Required | Purpose |
+|--------|----------|---------|
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Yes | Full Workload Identity Provider resource name |
+| `GCP_SERVICE_ACCOUNT` | Yes | Service account email |
+| `GOOGLE_SHEET_FILE_ID` | Yes | Spreadsheet ID from the Google Sheet URL |
+| `GEMINI_API_KEY` | No | Richer PR description; falls back to the raw diff report if unset |
+
+`GITHUB_TOKEN` is provided automatically for PR creation.
+
+> **Note:** Many organizations block service account JSON keys (`iam.disableServiceAccountKeyCreation`). This repo uses **Workload Identity Federation** so GitHub Actions can authenticate without a key file.
+
+### Add GitHub secrets
+
+In the **sc-data-format** repo: **Settings → Secrets and variables → Actions → New repository secret**.
+
+Create one secret per row below:
+
+| Secret name | What to paste | Where to find it |
+|-------------|---------------|------------------|
+| `GCP_SERVICE_ACCOUNT` | `firmware-signal-sheet-sync@firmware-signals-2-github-auto.iam.gserviceaccount.com` | **IAM & Admin → Service Accounts** → your service account email |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-pool/providers/github-provider` | **IAM & Admin → Workload Identity Federation** → `github-pool` → `github-provider` → copy the full provider resource name |
+| `GOOGLE_SHEET_FILE_ID` | The long ID between `/d/` and `/edit` in the sheet URL | Open the Google Sheet; URL looks like `https://docs.google.com/spreadsheets/d/<FILE_ID>/edit` |
+
+Optional fourth secret:
+
+| Secret name | What to paste | Where to find it |
+|-------------|---------------|------------------|
+| `GEMINI_API_KEY` | API key string | [Google AI Studio](https://aistudio.google.com/apikey) (not Cloud Console) |
+
+## Google Cloud setup
+
+### Tip: Cloud Console Gemini assistant
+
+The [Google Cloud Console](https://console.cloud.google.com/) includes a **Gemini** assistant (chat icon in the top bar). It can help you locate values for this setup without clicking through every page. Useful prompts:
+
+- *"What is my project number for firmware-signals-2-github-auto?"*
+- *"What is the full resource name for workload identity provider github-provider in pool github-pool?"*
+- *"Show me the email for service account firmware-signal-sheet-sync"*
+- *"Is the Google Drive API enabled in this project?"*
+
+Use the assistant for navigation and IDs; still add the three required values as **GitHub Actions secrets** in the repo (not in GCP).
+
+### 1. Project and Drive API
+
+1. Open [Google Cloud Console](https://console.cloud.google.com/) and select your project (e.g. `firmware-signals-2-github-auto`).
+2. Enable the **Google Drive API** (APIs & Services → Library → Google Drive API → Enable).
+
+### 2. Service account (no JSON key)
+
+1. **IAM & Admin → Service Accounts → Create service account**
+   - Name: `Firmware Signal Sheet Sync`
+   - ID: `firmware-signal-sheet-sync`
+   - Description: read-only access to the firmware signal spreadsheet for GitHub Actions
+2. Skip granting project roles (not needed for a shared sheet).
+3. **Do not create a JSON key** if your org blocks key creation.
+
+### 3. Share the spreadsheet
+
+Share the Google Sheet with the service account email as **Viewer**:
+
+```
+firmware-signal-sheet-sync@firmware-signals-2-github-auto.iam.gserviceaccount.com
+```
+
+Copy the sheet ID for the `GOOGLE_SHEET_FILE_ID` GitHub secret (see [Add GitHub secrets](#add-github-secrets)).
+
+### 4. Workload Identity Federation pool
+
+**IAM & Admin → Workload Identity Federation → Create pool**
+
+| Field | Value |
+|-------|--------|
+| Pool name | `GitHub Pool` |
+| Pool ID | `github-pool` |
+| Description | GitHub Actions OIDC for firmware signal spreadsheet sync |
+
+### 5. Add OIDC provider to the pool
+
+| Field | Value |
+|-------|--------|
+| Provider type | OpenID Connect (OIDC) |
+| Provider name | `GitHub Provider` |
+| Provider ID | `github-provider` |
+| Issuer URL | `https://token.actions.githubusercontent.com` |
+
+**Attribute mapping**
+
+| Google attribute | OIDC claim |
+|------------------|------------|
+| `google.subject` | `assertion.sub` |
+| `attribute.repository` | `assertion.repository` |
+| `attribute.repository_owner` | `assertion.repository_owner` |
+
+**Attribute condition** (limit to this repo):
+
+```
+assertion.repository == 'badgerloop-software/sc-data-format'
+```
+
+Or, to allow any repo under the org:
+
+```
+assertion.repository_owner == 'badgerloop-software'
+```
+
+### 6. Allow GitHub to impersonate the service account
+
+Find your **project number** (Home → Project settings, or `gcloud projects describe PROJECT_ID --format='value(projectNumber)'`).
+
+Run (replace `PROJECT_NUMBER` and the service account email if different):
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  firmware-signal-sheet-sync@firmware-signals-2-github-auto.iam.gserviceaccount.com \
+  --project=firmware-signals-2-github-auto \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-pool/attribute.repository/badgerloop-software/sc-data-format"
+```
+
+**Console (current UI):** open the service account → **Permissions** tab → under **Principals with access to this service account**, click **View Principals with access** → **Grant access** → add the `principalSet://…` principal above with role **Workload Identity User**.
+
+Do **not** use **Manage service account permissions** — that assigns project roles *to* the service account and is not needed for sheet read access.
+
+When done, **Principals with access** should show a `…github-pool/…sc-data-format` principal with role **Workload Identity User**.
+
+### 7. Add GitHub secrets
+
+After GCP setup, add the three required secrets in GitHub (see [Add GitHub secrets](#add-github-secrets)).
+
+## Ready to test
+
+1. GCP: Drive API enabled, sheet shared with service account, WIF pool + provider created, Workload Identity User binding added.
+2. GitHub: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, and `GOOGLE_SHEET_FILE_ID` secrets set.
+3. Repo: workflow file `.github/workflows/sync-format-from-sheet.yml` is on the default branch.
+4. Run **Actions → Sync format.json from spreadsheet** with **dry_run** checked first.
+
+## Local dry-run
+
+Local runs use a downloaded `.xlsx` file and do not need GCP credentials:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r tools/requirements.txt
+
+python tools/sync_format.py \
+  --local-xlsx /path/to/Firmware\ Signal\ Spreadsheet.xlsx \
+  --dry-run
+```
+
+Review `tools/reports/sync-report.md` for added/changed signals before running the workflow without `dry_run`.
+
+## Software and Race Strategy tabs
+
+These tabs use the same columns as `Better Template`. They produce `FFF` placeholder entries (not decoded from CAN):
+
+- **Software** — section headers `Timestamp`, `GPS`, and `Lap Counter` set the category (`Software;Timestamp`, etc.).
+- **Race Strategy** — all rows map to `Race Strategy;Model Outputs`. Use **Serial** direction for cloud-sim values the Pi forwards onto the bus.
+
+If a tab is missing from the workbook, the sync skips it and leaves those signals unchanged.
+
+## Fallback: service account JSON key
+
+If your organization allows JSON keys, you can instead set `GOOGLE_SERVICE_ACCOUNT_JSON` to the full key contents and remove the `google-github-actions/auth` step from the workflow. Workload Identity Federation is preferred when keys are disabled.

--- a/.github/workflows/sync-format-from-sheet.yml
+++ b/.github/workflows/sync-format-from-sheet.yml
@@ -1,0 +1,69 @@
+name: Sync format.json from spreadsheet
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Parse and report only (do not open PR)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Install dependencies
+        run: pip install -r tools/requirements.txt
+
+      - name: Sync format.json from Google Sheet
+        env:
+          GOOGLE_SHEET_FILE_ID: ${{ secrets.GOOGLE_SHEET_FILE_ID }}
+        run: |
+          ARGS="--report tools/reports/sync-report.md"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          python tools/sync_format.py $ARGS
+
+      - name: Generate PR body
+        if: inputs.dry_run != true
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          python tools/llm_pr_body.py tools/reports/sync-report.md > tools/reports/pr-body.md
+
+      - name: Create pull request
+        if: inputs.dry_run != true
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: automation/format-sync
+          delete-branch: true
+          title: "Sync format.json from signal spreadsheet"
+          body-path: tools/reports/pr-body.md
+          commit-message: "Sync format.json from firmware signal spreadsheet"
+          labels: automation
+
+      - name: Upload sync report
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-report
+          path: tools/reports/sync-report.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+tools/downloads/
+tools/reports/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ The following information is listed within the format for each piece of data bei
 For each piece of data, the information described above will be listed as follows:
 
 &emsp;"name": [\<<i>num bytes</i>\>, "data_type", "units", \<<i>nominal min</i>\>, \<<i>nominal max</i>\>, "Category/Subsystem", "CAN ID (hex)", <i>bit offset</i>]
+
+## Spreadsheet sync
+
+`format.json` can be updated automatically from the firmware signal spreadsheet. In the repo, go to **Actions → Sync format.json from spreadsheet → Run workflow** to parse the sheet and open a PR with any changes. Check **dry_run** to generate a diff report only, without opening a PR.
+
+See [Sheet sync setup](.github/SHEET_SYNC_SETUP.md) for GCP Workload Identity Federation, GitHub secrets, and local dry-run instructions.

--- a/tools/config.yaml
+++ b/tools/config.yaml
@@ -1,0 +1,226 @@
+# Spreadsheet → format.json sync configuration
+
+skip_sheet_patterns:
+  - "SC1"
+skip_sheets:
+  - "Title Page"
+  - "Better Template"
+
+# Tabs parsed from the workbook (BMS is preserved from existing format.json)
+parse_sheets:
+  - PDC_SC2
+  - "Steering Wheel"
+  - MPPT
+  - Powertrain
+  - MCC
+  - Software
+  - "Race Strategy"
+
+preserve_categories:
+  - "Battery;BMS"
+  - "Battery;Firmware"
+
+# Section headers inside the Software tab (first column only)
+software_sections:
+  Timestamp: "Software;Timestamp"
+  GPS: "Software;GPS"
+  "Lap Counter": "Software;Lap Counter"
+
+race_strategy_category: "Race Strategy;Model Outputs"
+
+# Rename duplicate firmware names across boards
+key_overrides:
+  PDC_SC2:
+    regen_brake: regen_brake_pdc
+  "Steering Wheel":
+    regen_brake: regen_brake_steering
+    crz_main: crz_mode_a
+    crz_inc: crz_set
+    crz_dec: crz_reset
+  Powertrain:
+    ESTOP_MCU: estop_mcu
+    BATT_POS_CONT_MCU: batt_pos_cont
+    MCU_BATT_EN: mcu_batt_en
+    MC_CONT_MCU: mc_cont_mcu
+    MPPT_CONT_MCU: mppt_cont_mcu
+    PPC1_DCDC_INVALID: ppc1_dcdc_invalid
+    PPC1_SUPP_INVALID: ppc1_supp_invalid
+
+# format.json category per signal key
+category_by_key:
+  # MCC
+  crz_pwr_mode: "MCC;Driver Buttons/Switches"
+  main_telem: "MCC;Driver Buttons/Switches"
+  crz_pwr_setpt: "MCC;Firmware"
+  crz_spd_setpt: "MCC;Firmware"
+  mcc_state: "MCC;Firmware"
+  motor_power: "MCC;Firmware"
+  foot_brake: "MCC;Sensors"
+  motor_current: "MCC;Sensors"
+  # PDC
+  eco_mode: "PDC;Motor Controller I/O"
+  mc_speed_sig: "PDC;Motor Controller I/O"
+  direction: "PDC;Motor Controller I/O"
+  mph: "PDC;Motor Controller I/O"
+  acc_out: "PDC;Motor Controller I/O"
+  mc_on: "PDC;Motor Controller I/O"
+  regen_brake_pdc: "PDC;Motor Controller I/O"
+  lv_12V_telem: "PDC;Sensors"
+  lv_5V_telem: "PDC;Sensors"
+  lv_5V_current: "PDC;Sensors"
+  park_brake: "PDC;Sensors"
+  acc_in: "PDC;Sensors"
+  current_in_telem: "PDC;Sensors"
+  brake_pressure_telem: "PDC;Sensors"
+  # Powertrain
+  batt_i: "Powertrain;Sensors"
+  i_12v: "Powertrain;Sensors"
+  supp_i: "Powertrain;Sensors"
+  supp_v: "Powertrain;Sensors"
+  v_12v: "Powertrain;Sensors"
+  batt_pos_cont: "Powertrain;Status"
+  batt_neg_cont: "Powertrain;Status"
+  estop_mcu: "Powertrain;Status"
+  mc_cont_mcu: "Powertrain;Status"
+  mcu_batt_en: "Powertrain;Status"
+  mppt_cont_mcu: "Powertrain;Status"
+  ppc1_dcdc_invalid: "Powertrain;Status"
+  ppc1_supp_invalid: "Powertrain;Status"
+  # MPPT
+  boost_enabled: "Solar Array;MPPT"
+  charge_mode: "Solar Array;MPPT"
+  string1_i_in: "Solar Array;Sensors"
+  string1_v_in: "Solar Array;Sensors"
+  string1_temp: "Solar Array;Sensors"
+  string1_duty_cycle: "Solar Array;MPPT"
+  string1_target_voltage: "Solar Array;MPPT"
+  string2_i_in: "Solar Array;Sensors"
+  string2_v_in: "Solar Array;Sensors"
+  string2_temp: "Solar Array;Sensors"
+  string2_duty_cycle: "Solar Array;MPPT"
+  string2_target_voltage: "Solar Array;MPPT"
+  string3_i_in: "Solar Array;Sensors"
+  string3_v_in: "Solar Array;Sensors"
+  string3_temp: "Solar Array;Sensors"
+  string3_duty_cycle: "Solar Array;MPPT"
+  string3_target_voltage: "Solar Array;MPPT"
+  # Steering
+  headlight: "Steering Wheel;Lights"
+  left_blink: "Steering Wheel;Lights"
+  right_blink: "Steering Wheel;Lights"
+  hazards: "Steering Wheel;Lights"
+  direction_switch: "Steering Wheel;Driver Buttons/Switches"
+  horn: "Steering Wheel;Driver Buttons/Switches"
+  crz_mode_a: "Steering Wheel;Driver Buttons/Switches"
+  crz_set: "Steering Wheel;Driver Buttons/Switches"
+  crz_reset: "Steering Wheel;Driver Buttons/Switches"
+  drive_mode: "Steering Wheel;Driver Buttons/Switches"
+  regen_brake_steering: "Steering Wheel;Sensors"
+  throttle: "Steering Wheel;Sensors"
+  # Software
+  elev: "Software;GPS"
+  lat: "Software;GPS"
+  lon: "Software;GPS"
+  current_section: "Software;Lap Counter"
+  lap_count: "Software;Lap Counter"
+  lap_duration: "Software;Lap Counter"
+  tstamp_hr: "Software;Timestamp"
+  tstamp_mn: "Software;Timestamp"
+  tstamp_sc: "Software;Timestamp"
+  tstamp_ms: "Software;Timestamp"
+  tstamp_unix: "Software;Timestamp"
+  # Race Strategy
+  maximum_distance_traveled: "Race Strategy;Model Outputs"
+  optimized_target_power: "Race Strategy;Model Outputs"
+
+# MCC rows map by schematic name (uppercase) or signal title
+mcc_schematic_to_key:
+  MAIN_TELEM: main_telem
+  CRZ_MODE_B_TELEM: crz_pwr_mode
+  BRK_TELEM: foot_brake
+
+mcc_title_to_key:
+  "Motor Power Setpoint": crz_pwr_setpt
+  "Motor Speed Setpoint": crz_spd_setpt
+  "MCC state": mcc_state
+  "Motor power": motor_power
+  "Motor current": motor_current
+
+# MPPT rows without firmware names — map by row label (first column)
+mppt_label_to_key:
+  "Boost Converter Enable": boost_enabled
+  "MPPT Mode": charge_mode
+  "Array 1 Voltage": string1_v_in
+  "Array 1 Current": string1_i_in
+  "Array 1 Temperature": string1_temp
+  "Array 1 PWM": string1_duty_cycle
+  "Array 1 Target": string1_target_voltage
+  "Array 2 Voltage": string2_v_in
+  "Array 2 Current": string2_i_in
+  "Array 2 Temperature": string2_temp
+  "Array 2 PWM": string2_duty_cycle
+  "Array 2 Target": string2_target_voltage
+  "Array 3 Voltage": string3_v_in
+  "Array 3 Current": string3_i_in
+  "Array 3 Temperature": string3_temp
+  "Array 3 PWM": string3_duty_cycle
+  "Array 3 Target": string3_target_voltage
+
+# Units and nominal ranges when not present in the sheet
+signal_defaults:
+  maximum_distance_traveled: {units: m, min: 0, max: 100000}
+  optimized_target_power: {units: kW, min: 0, max: 10}
+  elev: {units: meter, min: 0, max: 0}
+  lat: {units: Degree, min: 0, max: 0}
+  lon: {units: Degree, min: 0, max: 0}
+  current_section: {units: "", min: 0, max: 100, data_type: int32}
+  lap_count: {units: "", min: 0, max: 1000, data_type: int32}
+  lap_duration: {units: ms, min: 0, max: 600000, data_type: uint32}
+  tstamp_hr: {units: "", min: 0, max: 23, data_type: uint8}
+  tstamp_mn: {units: "", min: 0, max: 59, data_type: uint8}
+  tstamp_sc: {units: "", min: 0, max: 59, data_type: uint8}
+  tstamp_ms: {units: "", min: 0, max: 999, data_type: uint16}
+  tstamp_unix: {units: ms, min: 0, max: 0, data_type: uint32}
+  throttle: {units: "", min: 0, max: 4095}
+  mcc_state: {units: "", min: 0, max: 7}
+  drive_mode: {units: "", min: 0, max: 1, data_type: uint8}
+  batt_i: {units: A, min: -50, max: 50}
+  acc_out: {units: V, min: 0, max: 3.3}
+  acc_in: {units: V, min: 0, max: 3.3}
+  regen_brake_pdc: {units: V, min: 0, max: 3.3}
+  regen_brake_steering: {units: V, min: 0, max: 3.3}
+  brake_pressure_telem: {units: V, min: 0, max: 3.3}
+  lv_12V_telem: {units: V, min: 0, max: 50}
+  lv_5V_telem: {units: V, min: 0, max: 10}
+  string1_temp: {units: degC, min: 20, max: 50}
+  string2_temp: {units: degC, min: 20, max: 50}
+  string3_temp: {units: degC, min: 20, max: 50}
+
+# Output key order (blank line inserted after each group tail key)
+section_order:
+  - group: bms
+    keys: []  # filled from preserved entries
+  - group: pack_power
+    keys: [pack_power]
+  - group: mcc
+    keys: [crz_pwr_mode, main_telem, crz_pwr_setpt, crz_spd_setpt, mcc_state, motor_power, foot_brake, motor_current]
+  - group: pdc_motor
+    keys: [eco_mode, mc_speed_sig, direction, mph, acc_out]
+  - group: pdc_sensors
+    keys: [lv_12V_telem, lv_5V_telem, lv_5V_current, park_brake, acc_in, current_in_telem, brake_pressure_telem, mc_on, regen_brake_pdc]
+  - group: powertrain_sensors
+    keys: [batt_i, i_12v, supp_i, supp_v, v_12v]
+  - group: powertrain_status
+    keys: [batt_pos_cont, batt_neg_cont, estop_mcu, mc_cont_mcu, mcu_batt_en, mppt_cont_mcu, ppc1_dcdc_invalid, ppc1_supp_invalid]
+  - group: race_strategy
+    keys: [maximum_distance_traveled, optimized_target_power]
+  - group: software_gps
+    keys: [elev, lat, lon]
+  - group: software_lap
+    keys: [current_section, lap_count, lap_duration]
+  - group: software_timestamp
+    keys: [tstamp_hr, tstamp_mn, tstamp_sc, tstamp_ms, tstamp_unix]
+  - group: mppt
+    keys: [boost_enabled, charge_mode, string1_i_in, string1_v_in, string1_temp, string1_duty_cycle, string1_target_voltage, string2_i_in, string2_v_in, string2_temp, string2_duty_cycle, string2_target_voltage, string3_i_in, string3_v_in, string3_temp, string3_duty_cycle, string3_target_voltage]
+  - group: steering
+    keys: [headlight, left_blink, right_blink, hazards, direction_switch, horn, crz_mode_a, crz_set, crz_reset, regen_brake_steering, throttle, drive_mode]

--- a/tools/diff_report.py
+++ b/tools/diff_report.py
@@ -1,0 +1,72 @@
+"""Generate a human-readable diff report for format.json sync."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sheet_parser import ParsedSignal
+
+
+def _fmt_entry(entry: list[Any]) -> str:
+    return json.dumps(entry, separators=(", ", ": "))
+
+
+def build_report(
+    before: dict[str, list[Any]],
+    after: dict[str, list[Any]],
+    parsed: list[ParsedSignal],
+    notes: list[str],
+) -> str:
+    added = sorted(set(after) - set(before))
+    removed = sorted(set(before) - set(after))
+    common = sorted(set(before) & set(after))
+
+    changed: list[tuple[str, list[Any], list[Any]]] = []
+    for key in common:
+        if before[key] != after[key]:
+            changed.append((key, before[key], after[key]))
+
+    flagged = [s for s in parsed if s.warnings]
+
+    lines = ["# format.json sync report", ""]
+    lines.append(f"- Signals before: **{len(before)}**")
+    lines.append(f"- Signals after: **{len(after)}**")
+    lines.append(f"- Added: **{len(added)}** | Removed: **{len(removed)}** | Changed: **{len(changed)}**")
+    lines.append("")
+
+    if added:
+        lines.append("## Added signals")
+        for key in added:
+            lines.append(f"- `{key}`: {_fmt_entry(after[key])}")
+        lines.append("")
+
+    if removed:
+        lines.append("## Removed signals")
+        for key in removed:
+            lines.append(f"- `{key}`: {_fmt_entry(before[key])}")
+        lines.append("")
+
+    if changed:
+        lines.append("## Changed signals")
+        for key, old, new in changed:
+            lines.append(f"- `{key}`")
+            lines.append(f"  - before: {_fmt_entry(old)}")
+            lines.append(f"  - after: {_fmt_entry(new)}")
+        lines.append("")
+
+    if flagged:
+        lines.append("## Flagged rows (needs review)")
+        for signal in flagged:
+            lines.append(
+                f"- `{signal.key}` ({signal.sheet} row {signal.row}): {', '.join(signal.warnings)}"
+            )
+        lines.append("")
+
+    if notes:
+        lines.append("## Parser notes")
+        for note in notes:
+            lines.append(f"- {note}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tools/drive_download.py
+++ b/tools/drive_download.py
@@ -1,0 +1,66 @@
+"""Download the signal spreadsheet from Google Drive."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+
+import google.auth
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload
+
+
+EXPORT_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+
+
+def _credentials():
+    raw = os.environ.get("GOOGLE_SERVICE_ACCOUNT_JSON")
+    if raw:
+        info = json.loads(raw)
+        return service_account.Credentials.from_service_account_info(
+            info,
+            scopes=DRIVE_SCOPES,
+        )
+    path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if path and Path(path).is_file():
+        return service_account.Credentials.from_service_account_file(
+            path,
+            scopes=DRIVE_SCOPES,
+        )
+    creds, _ = google.auth.default(scopes=DRIVE_SCOPES)
+    if creds:
+        return creds
+    raise RuntimeError(
+        "No Google credentials found. Use Workload Identity Federation in CI, "
+        "or set GOOGLE_SERVICE_ACCOUNT_JSON / GOOGLE_APPLICATION_CREDENTIALS locally."
+    )
+
+
+def download_spreadsheet(file_id: str, output_path: str) -> str:
+    creds = _credentials()
+    service = build("drive", "v3", credentials=creds, cache_discovery=False)
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        request = service.files().export_media(fileId=file_id, mimeType=EXPORT_MIME)
+        return _write_request(request, output_path)
+    except HttpError as err:
+        if err.resp.status not in (400, 403, 404):
+            raise
+        request = service.files().get_media(fileId=file_id)
+        return _write_request(request, output_path)
+
+
+def _write_request(request, output_path: str) -> str:
+    buffer = io.BytesIO()
+    downloader = MediaIoBaseDownload(buffer, request)
+    done = False
+    while not done:
+        _, done = downloader.next_chunk()
+    Path(output_path).write_bytes(buffer.getvalue())
+    return output_path

--- a/tools/format_generator.py
+++ b/tools/format_generator.py
@@ -1,0 +1,115 @@
+"""Build format.json content from parsed spreadsheet signals."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sheet_parser import ParsedSignal, _type_bytes
+
+
+def _load_existing(path: str) -> dict[str, list[Any]]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _entry_from_signal(signal: ParsedSignal, existing: dict[str, list[Any]], config: dict[str, Any]) -> list[Any]:
+    if signal.key in existing:
+        old = existing[signal.key]
+        units = old[2] if old[2] else signal.units
+        nmin = old[3] if old[3] != 100 or signal.nominal_min == 0 else signal.nominal_min
+        nmax = old[4] if old[4] != 100 or signal.nominal_max == 100 else signal.nominal_max
+        category = signal.category or old[5]
+    else:
+        units = signal.units
+        nmin = signal.nominal_min
+        nmax = signal.nominal_max
+        category = signal.category
+
+    defaults = config.get("signal_defaults", {}).get(signal.key, {})
+    data_type = defaults.get("data_type", signal.data_type)
+    nbytes = _type_bytes(data_type)
+    if signal.key in existing:
+        old = existing[signal.key]
+        nbytes = old[0]
+        data_type = old[1]
+
+    return [
+        nbytes,
+        data_type,
+        units,
+        nmin,
+        nmax,
+        category,
+        signal.can_id,
+        signal.bit_offset,
+    ]
+
+
+def merge_signals(
+    existing_path: str,
+    parsed: list[ParsedSignal],
+    config: dict[str, Any],
+) -> tuple[dict[str, list[Any]], list[ParsedSignal]]:
+    existing = _load_existing(existing_path)
+    # Update-only merge: start from the committed file and overlay parsed rows.
+    merged = dict(existing)
+
+    duplicates: dict[str, ParsedSignal] = {}
+    for signal in parsed:
+        if signal.key in duplicates:
+            signal.warnings.append(
+                f"duplicate key also defined on {duplicates[signal.key].sheet} row {duplicates[signal.key].row}"
+            )
+        duplicates[signal.key] = signal
+        merged[signal.key] = _entry_from_signal(signal, existing, config)
+
+    return merged, list(duplicates.values())
+
+
+def _ordered_keys(merged: dict[str, list[Any]], config: dict[str, Any]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    bms_keys = sorted(k for k, v in merged.items() if v[5] == "Battery;BMS")
+    for key in bms_keys:
+        ordered.append(key)
+        seen.add(key)
+
+    for section in config.get("section_order", []):
+        for key in section.get("keys", []):
+            if key in merged and key not in seen:
+                ordered.append(key)
+                seen.add(key)
+
+    for key in sorted(merged):
+        if key not in seen:
+            ordered.append(key)
+
+    return ordered
+
+
+def render_format_json(merged: dict[str, list[Any]], config: dict[str, Any]) -> str:
+    keys = _ordered_keys(merged, config)
+    lines = ["{"]
+
+    section_tails: set[str] = set()
+    for section in config.get("section_order", []):
+        section_keys = section.get("keys", [])
+        if section_keys:
+            section_tails.add(section_keys[-1])
+
+    last_bms = sorted(k for k, v in merged.items() if v[5] == "Battery;BMS")[-1] if any(
+        v[5] == "Battery;BMS" for v in merged.values()
+    ) else None
+
+    for idx, key in enumerate(keys):
+        value = merged[key]
+        comma = "," if idx < len(keys) - 1 else ""
+        lines.append(f'  "{key}": {json.dumps(value, separators=(", ", ": "))}{comma}')
+        if key == last_bms or key in section_tails:
+            if idx < len(keys) - 1:
+                lines.append("")
+
+    lines.append("}")
+    return "\n".join(lines) + "\n"

--- a/tools/llm_pr_body.py
+++ b/tools/llm_pr_body.py
@@ -1,0 +1,62 @@
+"""Optional Gemini-generated PR description from sync diff report."""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def generate_pr_body(report_path: str) -> str:
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        return _fallback_body(report_path)
+
+    report = open(report_path, encoding="utf-8").read()
+    prompt = (
+        "Write a concise GitHub pull request description in markdown for a telemetry "
+        "format.json sync from the firmware signal spreadsheet. Summarize added, removed, "
+        "and changed signals. Call out anything flagged for review. Include a short test plan.\n\n"
+        f"Report:\n{report}"
+    )
+
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"gemini-2.0-flash:generateContent?key={api_key}"
+    )
+    payload = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"temperature": 0.2},
+    }
+
+    import json
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        text = data["candidates"][0]["content"]["parts"][0]["text"]
+        return text.strip() + "\n"
+    except (urllib.error.URLError, KeyError, IndexError, TimeoutError):
+        return _fallback_body(report_path)
+
+
+def _fallback_body(report_path: str) -> str:
+    report = open(report_path, encoding="utf-8").read()
+    return (
+        "## Summary\n"
+        "Automated sync of `format.json` from the firmware signal spreadsheet.\n\n"
+        "## Diff report\n"
+        f"{report}\n"
+    )
+
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "tools/reports/sync-report.md"
+    print(generate_pr_body(path))

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,4 @@
+openpyxl>=3.1.0
+PyYAML>=6.0
+google-api-python-client>=2.100.0
+google-auth>=2.23.0

--- a/tools/sheet_parser.py
+++ b/tools/sheet_parser.py
@@ -1,0 +1,300 @@
+"""Parse Firmware Signal Spreadsheet tabs into normalized signal records."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import openpyxl
+
+
+@dataclass
+class ParsedSignal:
+    key: str
+    sheet: str
+    row: int
+    data_type: str
+    can_id: str
+    bit_offset: int
+    category: str
+    units: str = ""
+    nominal_min: float = 0
+    nominal_max: float = 100
+    firmware_name: str = ""
+    schematic_name: str = ""
+    warnings: list[str] = field(default_factory=list)
+
+
+def _norm_header(value: Any) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value).strip()).lower()
+
+
+def _cell_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _find_header_row(rows: list[tuple[Any, ...]]) -> tuple[int, dict[str, int]]:
+    for idx, row in enumerate(rows):
+        mapping: dict[str, int] = {}
+        for col, cell in enumerate(row):
+            key = _norm_header(cell)
+            if not key:
+                continue
+            if key in ("firmware name", "signal name [firmware name]"):
+                mapping["firmware_name"] = col
+            elif key == "schematic name":
+                mapping["schematic_name"] = col
+            elif key in ("data type", "signal type"):
+                mapping["data_type"] = col
+            elif key == "can message id":
+                mapping["can_id"] = col
+            elif key in ("bit offset", "bit offset "):
+                mapping["bit_offset"] = col
+            elif key == "units":
+                mapping["units"] = col
+        if "data_type" in mapping and ("firmware_name" in mapping or "schematic_name" in mapping):
+            return idx, mapping
+    raise ValueError("Could not locate header row")
+
+
+def _normalize_type(raw: str) -> str:
+    value = raw.strip().lower()
+    mapping = {
+        "boolean": "bool",
+        "bool": "bool",
+        "float": "float",
+        "integer": "uint8",
+        "int": "int32",
+        "int32": "int32",
+        "uint8": "uint8",
+        "uint16": "uint16",
+        "uint32": "uint32",
+    }
+    return mapping.get(value, value)
+
+
+def _type_bytes(data_type: str) -> int:
+    return {
+        "bool": 1,
+        "uint8": 1,
+        "uint16": 2,
+        "uint32": 4,
+        "int32": 4,
+        "float": 4,
+    }.get(data_type, 4)
+
+
+def _normalize_can_id(raw: Any) -> str:
+    if raw is None or raw == "":
+        return "FFF"
+    text = str(raw).strip()
+    if text.upper() in ("FFF", "N/A", "NA", "NONE"):
+        return "FFF"
+    text = text.lower().replace("0x", "").replace("x", "")
+    if "." in text:
+        text = text.split(".", 1)[0]
+    try:
+        # CAN IDs are hexadecimal; plain digits like 209 mean 0x209, not decimal 209.
+        value = int(text, 16)
+        return format(value, "X")
+    except ValueError:
+        return "FFF"
+
+
+def _normalize_bit_offset(raw: Any) -> int:
+    if raw is None or raw == "":
+        return 0
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _should_skip_sheet(name: str, config: dict[str, Any]) -> bool:
+    if name in config.get("skip_sheets", []):
+        return True
+    for pattern in config.get("skip_sheet_patterns", []):
+        if pattern in name:
+            return True
+    return False
+
+
+def _is_example_row(firmware_name: str, schematic_name: str) -> bool:
+    combined = f"{firmware_name} {schematic_name}".lower()
+    return combined.startswith("ex") or "example" in combined
+
+
+def _resolve_software_category(first_col: str, current: str | None, config: dict[str, Any]) -> str | None:
+    sections = config.get("software_sections", {})
+    for label, category in sections.items():
+        if first_col.strip().lower() == label.strip().lower():
+            return category
+    return current
+
+
+def _mcc_key(
+    firmware_name: str,
+    schematic_name: str,
+    row_label: str,
+    config: dict[str, Any],
+) -> str | None:
+    title_key = config.get("mcc_title_to_key", {}).get(firmware_name.strip())
+    if title_key:
+        return title_key
+    title_key = config.get("mcc_title_to_key", {}).get(row_label.strip())
+    if title_key:
+        return title_key
+    schematic_key = config.get("mcc_schematic_to_key", {}).get(schematic_name.upper())
+    if schematic_key:
+        return schematic_key
+    return None
+
+
+def _mppt_key(row_label: str, config: dict[str, Any]) -> str | None:
+    labels = config.get("mppt_label_to_key", {})
+    label = row_label.strip()
+    if label in labels:
+        return labels[label]
+    for candidate, key in labels.items():
+        if candidate.strip() == label:
+            return key
+    return None
+
+
+def _resolve_key(
+    sheet: str,
+    firmware_name: str,
+    schematic_name: str,
+    row_label: str,
+    config: dict[str, Any],
+) -> str | None:
+    overrides = config.get("key_overrides", {}).get(sheet, {})
+
+    if sheet == "MCC":
+        return _mcc_key(firmware_name, schematic_name, row_label, config)
+
+    if sheet == "MPPT":
+        return _mppt_key(row_label, config)
+
+    if firmware_name:
+        base = firmware_name.strip()
+        if base in overrides:
+            return overrides[base]
+        upper = base.upper()
+        if upper in overrides:
+            return overrides[upper]
+        return base
+
+    if schematic_name:
+        return schematic_name.strip().lower()
+    return None
+
+
+def parse_workbook(path: str, config: dict[str, Any]) -> tuple[list[ParsedSignal], list[str]]:
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    signals: list[ParsedSignal] = []
+    notes: list[str] = []
+
+    for sheet_name in wb.sheetnames:
+        if _should_skip_sheet(sheet_name, config):
+            notes.append(f"Skipped sheet: {sheet_name}")
+            continue
+        if sheet_name not in config.get("parse_sheets", []):
+            notes.append(f"Ignored sheet (not in parse_sheets): {sheet_name}")
+            continue
+
+        ws = wb[sheet_name]
+        rows = list(ws.iter_rows(values_only=True))
+        if not rows:
+            continue
+
+        header_idx, columns = _find_header_row(rows[:10])
+        software_category: str | None = None
+
+        for row_idx, row in enumerate(rows[header_idx + 1 :], start=header_idx + 2):
+            firmware_name = _cell_str(row[columns["firmware_name"]]) if "firmware_name" in columns else ""
+            schematic_name = _cell_str(row[columns["schematic_name"]]) if "schematic_name" in columns else ""
+            row_label = _cell_str(row[0])
+
+            if sheet_name == "Software":
+                maybe_section = _resolve_software_category(row_label, software_category, config)
+                if maybe_section and maybe_section != software_category and not firmware_name:
+                    software_category = maybe_section
+                    continue
+
+            if sheet_name == "Race Strategy" and not firmware_name and not row_label:
+                continue
+
+            firmware_name = firmware_name.strip()
+            key = _resolve_key(sheet_name, firmware_name, schematic_name, row_label, config)
+            if not key:
+                if row_label or firmware_name or schematic_name:
+                    notes.append(f"{sheet_name} row {row_idx}: no key mapping ({row_label or firmware_name or schematic_name})")
+                continue
+
+            known_keys = set(config.get("category_by_key", {}))
+            if known_keys and key not in known_keys:
+                continue
+
+            if _is_example_row(firmware_name, schematic_name):
+                continue
+
+            raw_type = _cell_str(row[columns["data_type"]]) if "data_type" in columns else ""
+            if not raw_type:
+                notes.append(f"{sheet_name} row {row_idx} ({key}): missing data type")
+                continue
+
+            data_type = _normalize_type(raw_type)
+            can_id = _normalize_can_id(row[columns["can_id"]]) if "can_id" in columns else "FFF"
+            bit_offset = _normalize_bit_offset(row[columns["bit_offset"]]) if "bit_offset" in columns else 0
+
+            if sheet_name in ("Software", "Race Strategy"):
+                can_id = "FFF"
+                bit_offset = 0
+
+            if sheet_name == "MCC":
+                can_id = "FFF"
+                bit_offset = 0
+
+            category = config.get("category_by_key", {}).get(key, "")
+            if sheet_name == "Software" and software_category:
+                category = software_category
+            if sheet_name == "Race Strategy":
+                category = config.get("race_strategy_category", "Race Strategy;Model Outputs")
+
+            defaults = config.get("signal_defaults", {}).get(key, {})
+            units = defaults.get("units", "")
+            if "units" in columns:
+                sheet_units = _cell_str(row[columns["units"]])
+                if sheet_units:
+                    units = sheet_units
+
+            warnings: list[str] = []
+            if data_type not in {"bool", "uint8", "uint16", "uint32", "int32", "float"}:
+                warnings.append(f"unknown data type '{raw_type}'")
+
+            signals.append(
+                ParsedSignal(
+                    key=key,
+                    sheet=sheet_name,
+                    row=row_idx,
+                    data_type=data_type,
+                    can_id=can_id,
+                    bit_offset=bit_offset,
+                    category=category,
+                    units=units,
+                    nominal_min=float(defaults.get("min", 0)),
+                    nominal_max=float(defaults.get("max", 100)),
+                    firmware_name=firmware_name,
+                    schematic_name=schematic_name,
+                    warnings=warnings,
+                )
+            )
+
+    wb.close()
+    return signals, notes

--- a/tools/sync_format.py
+++ b/tools/sync_format.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Sync format.json from the firmware signal spreadsheet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TOOLS_DIR.parent
+sys.path.insert(0, str(TOOLS_DIR))
+
+import yaml
+
+from diff_report import build_report
+from drive_download import download_spreadsheet
+from format_generator import merge_signals, render_format_json
+from sheet_parser import parse_workbook
+
+
+def _load_config(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _load_json(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(TOOLS_DIR / "config.yaml"))
+    parser.add_argument("--format", default=str(REPO_ROOT / "format.json"))
+    parser.add_argument("--local-xlsx", help="Use a local spreadsheet instead of Google Drive")
+    parser.add_argument("--sheet-file-id", help="Google Drive file ID (or GOOGLE_SHEET_FILE_ID env)")
+    parser.add_argument("--download-path", default=str(TOOLS_DIR / "downloads" / "spreadsheet.xlsx"))
+    parser.add_argument("--report", default=str(TOOLS_DIR / "reports" / "sync-report.md"))
+    parser.add_argument("--dry-run", action="store_true", help="Do not write format.json")
+    args = parser.parse_args()
+
+    config = _load_config(Path(args.config))
+    format_path = Path(args.format)
+
+    if args.local_xlsx:
+        xlsx_path = args.local_xlsx
+    else:
+        import os
+
+        file_id = args.sheet_file_id or os.environ.get("GOOGLE_SHEET_FILE_ID")
+        if not file_id:
+            print("error: provide --local-xlsx or --sheet-file-id / GOOGLE_SHEET_FILE_ID", file=sys.stderr)
+            return 2
+        xlsx_path = download_spreadsheet(file_id, args.download_path)
+        print(f"Downloaded spreadsheet to {xlsx_path}")
+
+    before = _load_json(format_path)
+    parsed, notes = parse_workbook(xlsx_path, config)
+    merged, parsed_signals = merge_signals(str(format_path), parsed, config)
+    after_text = render_format_json(merged, config)
+    after = json.loads(after_text)
+
+    report = build_report(before, after, parsed_signals, notes)
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(report, encoding="utf-8")
+    print(f"Wrote report to {report_path}")
+
+    if before == after:
+        print("No changes detected.")
+        return 0
+
+    if args.dry_run:
+        print("Dry run: format.json not written.")
+        return 0
+
+    format_path.write_text(after_text, encoding="utf-8")
+    print(f"Updated {format_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Parse firmware signal spreadsheet tabs into format.json via GitHub Actions, using Workload Identity Federation instead of service account keys, with local dry-run tooling and setup docs under .github/.

This pull request introduces a complete, automated pipeline for syncing `format.json` from the firmware signal spreadsheet using a new GitHub Actions workflow, with supporting documentation, configuration, and Python tooling. It enables both cloud-based and local dry-run syncs, with robust configuration and reporting. The main changes are grouped below:

**1. GitHub Actions Workflow and Documentation**
- Added a new workflow file (`.github/workflows/sync-format-from-sheet.yml`) to automate syncing `format.json` from the Google Sheet, supporting both dry-run and PR modes, and integrating with Google Cloud Workload Identity Federation for secure authentication.
- Added detailed setup documentation (`.github/SHEET_SYNC_SETUP.md`) covering GCP, GitHub secrets, and local testing instructions for the sync pipeline.
- Updated `README.md` with instructions for triggering the sync and linking to the new setup guide.

**2. Sync Configuration and Tooling**
- Introduced `tools/config.yaml` to centralize all spreadsheet parsing, signal mapping, and output ordering logic for the sync process.
- Added `tools/drive_download.py` to securely download the spreadsheet from Google Drive, supporting both Workload Identity Federation and service account key authentication.
- Implemented `tools/diff_report.py` to generate a clear, human-readable diff report of added, removed, and changed signals during sync, including parser notes and flagged rows for review.